### PR TITLE
Allowed int sig to be passed into shutdown(), was needed for compilation

### DIFF
--- a/wlinhibit.c
+++ b/wlinhibit.c
@@ -30,7 +30,7 @@ void registry_global_remove_handler(void *data, struct wl_registry *registry,
     // care?
 }
 
-void shutdown() {
+void shutdown(int sig) {
     // destroy the inhibitor on process exit
     zwp_idle_inhibitor_v1_destroy(idle_inhibitor);
     wl_surface_destroy(surface);
@@ -87,5 +87,5 @@ int main(void) {
         wl_display_dispatch(display);
     }
 
-    shutdown();
+    shutdown(0);
 }


### PR DESCRIPTION
I was trying to install this package from the AUR and was running into compilation issues, figured I could just compile from github source myself but hit the same issue:

```sh
[4/5] Compiling C object wlinhibit.p/wlinhibit.c.o
FAILED: wlinhibit.p/wlinhibit.c.o
cc -Iwlinhibit.p -I. -I../wlinhibit-0.1.1 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MD -MQ wlinhibit.p/wlinhibit.c.o -MF wlinhibit.p/wlinhibit.c.o.d -o wlinhibit.p/wlinhibit.c.o -c ../wlinhibit-0.1.1/wlinhibit.c
../wlinhibit-0.1.1/wlinhibit.c: In function ‘main’:
../wlinhibit-0.1.1/wlinhibit.c:83:20: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
   83 |     signal(SIGINT, shutdown);
      |                    ^~~~~~~~
      |                    |
      |                    void (*)(void)
In file included from ../wlinhibit-0.1.1/wlinhibit.c:1:
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
../wlinhibit-0.1.1/wlinhibit.c:33:6: note: ‘shutdown’ declared here
   33 | void shutdown() {
      |      ^~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
../wlinhibit-0.1.1/wlinhibit.c:84:21: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
   84 |     signal(SIGTERM, shutdown);
      |                     ^~~~~~~~
      |                     |
      |                     void (*)(void)
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
../wlinhibit-0.1.1/wlinhibit.c:33:6: note: ‘shutdown’ declared here
   33 | void shutdown() {
      |      ^~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
==> ERROR: A failure occurred in build().
    Aborting...
 -> error making: wlinhibit-exit status 4
 -> Failed to install the following packages. Manual intervention is required:
wlinhibit - exit status 4
```

Anyways, I fixed the function signature error just by allowing the function to accept an int signal, and it compiled with no issues.

Before:
```c
void shutdown() {
...
    shutdown();
```

After:
```c
void shutdown(int sig) {
...
    shutdown(0);
```